### PR TITLE
Fix kernel linker script

### DIFF
--- a/kernel.ld
+++ b/kernel.ld
@@ -26,16 +26,12 @@ SECTIONS
 		PROVIDE(__STAB_BEGIN__ = .);
 		*(.stab);
 		PROVIDE(__STAB_END__ = .);
-		BYTE(0)		/* Force the linker to allocate space
-				   for this section */
 	}
 
 	.stabstr : {
 		PROVIDE(__STABSTR_BEGIN__ = .);
 		*(.stabstr);
 		PROVIDE(__STABSTR_END__ = .);
-		BYTE(0)		/* Force the linker to allocate space
-				   for this section */
 	}
 
 	/* Adjust the address for the data segment to the next page */


### PR DESCRIPTION
Binutils upgrade to 2.33 breaks xv6. This fixes and still works for binutils 2.32. Currently not sure why this fixes the triple fault.